### PR TITLE
Fix search for LLVM to prefer LLVM_ROOT if specified

### DIFF
--- a/cpp/cmake_modules/FindLLVMAlt.cmake
+++ b/cpp/cmake_modules/FindLLVMAlt.cmake
@@ -19,18 +19,33 @@
 #
 #  find_package(LLVMAlt)
 
-set(LLVM_HINTS ${LLVM_ROOT} ${LLVM_DIR} /usr/lib /usr/share)
-if(LLVM_BREW_PREFIX)
-  list(APPEND LLVM_HINTS ${LLVM_BREW_PREFIX})
-endif()
-foreach(ARROW_LLVM_VERSION ${ARROW_LLVM_VERSIONS})
+if(LLVM_ROOT
+   OR LLVM_DIR
+   OR LLVM_BREW_PREFIX)
+  set(LLVM_HINTS ${LLVM_ROOT} ${LLVM_DIR})
+  if(LLVM_BREW_PREFIX)
+    list(APPEND LLVM_HINTS ${LLVM_BREW_PREFIX})
+  endif()
   find_package(LLVM
-               ${ARROW_LLVM_VERSION}
                CONFIG
                HINTS
-               ${LLVM_HINTS})
+               ${LLVM_HINTS}
+               NO_DEFAULT_PATH)
   if(LLVM_FOUND)
-    break()
+    if(NOT "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}" IN_LIST ARROW_LLVM_VERSIONS
+       AND NOT "${LLVM_VERSION_MAJOR}" IN_LIST ARROW_LLVM_VERSIONS)
+      message(FATAL_ERROR "LLVM version found in ${LLVM_ROOT};${LLVM_DIR};${LLVM_BREW_PREFIX} is not supported")
+    endif()
+  endif()
+endif()
+
+foreach(ARROW_LLVM_VERSION ${ARROW_LLVM_VERSIONS})
+  if(NOT LLVM_FOUND)
+    find_package(LLVM
+                 ${ARROW_LLVM_VERSION}
+                 CONFIG
+                 PATHS
+                 "/usr/lib;/usr/share")
   endif()
 endforeach()
 


### PR DESCRIPTION
If the system has LLVM 13, but we want to build with LLVM 12, this way we can set `LLVM_ROOT` or `LLVM_DIR` to force v12 to be used.

As far as I can tell, this works for me. In an slc8-gpu container, libgandiva is not linked against the system LLVM 13:

```
[root@d91eb64d9790 ~]# ldd sw/slc8_x86-64/arrow/v5.0.0-alice2-local1/lib/libgandiva.so
sw/slc8_x86-64/arrow/v5.0.0-alice2-local1/lib/libgandiva.so: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.26' not found (required by sw/slc8_x86-64/arrow/v5.0.0-alice2-local1/lib/libgandiva.so)
        linux-vdso.so.1 (0x00007ffc26199000)
        libarrow.so.500 => not found
        libcrypto.so.1.0.0 => /root/sw/slc8_x86-64/OpenSSL/v1.0.2o-6/lib/libcrypto.so.1.0.0 (0x00007f7e8341e000)
        libssl.so.1.0.0 => /root/sw/slc8_x86-64/OpenSSL/v1.0.2o-6/lib/libssl.so.1.0.0 (0x00007f7e8095d000)
        libutf8proc.so.2 => /root/sw/slc8_x86-64/utf8proc/v2.6.1-5/lib/libutf8proc.so.2 (0x00007f7e80908000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f7e80704000)
        librt.so.1 => /lib64/librt.so.1 (0x00007f7e804fc000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f7e802dc000)
        libz.so.1 => /root/sw/slc8_x86-64/zlib/v1.2.8-5/lib/libz.so.1 (0x00007f7e83403000)
        libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f7e800af000)
        libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f7e7fd1a000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f7e7f998000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f7e7f780000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f7e7f3bb000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f7e833c0000)
```